### PR TITLE
Replacing dict comprehensions for python 2.6 support

### DIFF
--- a/tcelery/connection.py
+++ b/tcelery/connection.py
@@ -25,7 +25,7 @@ class Connection(object):
         port = purl.port
 
         options = options or {}
-        options = {k.lstrip('DEFAULT_').lower(): v for k, v in options.items()}
+        options = dict([(k.lstrip('DEFAULT_').lower(), v) for k, v in options.items()])
         options.update(host=host, port=port, virtual_host=virtual_host,
                        credentials=credentials)
 


### PR DESCRIPTION
This fix was suggested by PyCharm. Py2.6 does not support dict comprehensions so for compatibility my IDE suggested to replace it with list comprehension :)
