### PR TITLE
Allow custom io loops for ConnectionPool

### DIFF
--- a/tcelery/__init__.py
+++ b/tcelery/__init__.py
@@ -19,7 +19,7 @@ def setup_nonblocking_producer(celery_app=None, io_loop=None,
     io_loop = io_loop or ioloop.IOLoop.instance()
 
     NonBlockingTaskProducer.app = celery_app
-    NonBlockingTaskProducer.conn_pool = ConnectionPool(limit=limit)
+    NonBlockingTaskProducer.conn_pool = ConnectionPool(limit, io_loop)
     NonBlockingTaskProducer.result_cls = result_cls
     if celery_app.conf['BROKER_URL'] and celery_app.conf['BROKER_URL'].startswith('amqp'):
         celery.app.amqp.AMQP.producer_cls = NonBlockingTaskProducer


### PR DESCRIPTION
`setup_nonblocking_producer` func doesn't pass ioloop to `ConnectionPool`, which force clients of _tornado-celery_ to use main IOLoop instance for TC.
