### PR TITLE
Re-add pika, celery and tornado dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     classifiers=classifiers,
     packages=find_packages(exclude=['tests', 'tests.*']),
     dependency_links=dependency_links,
+    install_requires=install_requires,
     entry_points={
         'console_scripts': [
             'tcelery = tcelery.__main__:main',


### PR DESCRIPTION
These were correct in the 9d48b8a2cb012cb4f127a6918a2e251b4e497546
commit, but got dropped in the
ccfcb7f7cfa2f91d5cdfc1d3dfe0dd3931fb690c merge
