### PR TITLE
allow producer class to be overridden in setup_nonblocking_producer

### DIFF
--- a/tcelery/__init__.py
+++ b/tcelery/__init__.py
@@ -14,21 +14,21 @@ __version__ = '.'.join(map(str, VERSION)) + '-dev'
 
 def setup_nonblocking_producer(celery_app=None, io_loop=None,
                                on_ready=None, result_cls=AsyncResult,
-                               limit=1):
+                               limit=1, producer_cls=NonBlockingTaskProducer):
     celery_app = celery_app or celery.current_app
     io_loop = io_loop or ioloop.IOLoop.instance()
 
-    NonBlockingTaskProducer.app = celery_app
-    NonBlockingTaskProducer.conn_pool = ConnectionPool(limit, io_loop)
-    NonBlockingTaskProducer.result_cls = result_cls
+    producer_cls.app = celery_app
+    producer_cls.conn_pool = ConnectionPool(limit, io_loop)
+    producer_cls.result_cls = result_cls
     if celery_app.conf['BROKER_URL'] and celery_app.conf['BROKER_URL'].startswith('amqp'):
-        celery.app.amqp.AMQP.producer_cls = NonBlockingTaskProducer
+        celery.app.amqp.AMQP.producer_cls = producer_cls
 
     def connect():
         broker_url = celery_app.connection().as_uri(include_password=True)
         options = celery_app.conf.get('CELERYT_PIKA_OPTIONS', {})
-        NonBlockingTaskProducer.conn_pool.connect(broker_url,
-                                                  options=options,
-                                                  callback=on_ready)
+        producer_cls.conn_pool.connect(broker_url,
+                                       options=options,
+                                       callback=on_ready)
 
     io_loop.add_callback(connect)


### PR DESCRIPTION
I need to override some methods on the NonBlockingTaskProducer with some custom functionality, so have changed the `setup_nonblocking_producer` function to optionally take in the class to use when performing its function
