### PR TITLE
Use CELERY_RESULT_PERSISTENT config to setup queue durability

### DIFF
--- a/tcelery/connection.py
+++ b/tcelery/connection.py
@@ -99,11 +99,11 @@ class Connection(object):
                                    body=body, properties=properties,
                                    mandatory=mandatory, immediate=immediate)
 
-    def consume(self, queue, callback, x_expires=None):
+    def consume(self, queue, callback, x_expires=None, persistent=True):
         assert self.channel
         self.channel.queue_declare(self.on_queue_declared, queue=queue,
                                    exclusive=False, auto_delete=True,
-                                   nowait=True, durable=True,
+                                   nowait=True, durable=persistent,
                                    arguments={'x-expires': x_expires})
         self.channel.basic_consume(callback, queue, no_ack=True)
 

--- a/tcelery/redis.py
+++ b/tcelery/redis.py
@@ -53,7 +53,7 @@ class RedisConsumer(object):
         self.client.connect()
         self.subscriber = CelerySubscriber(self.client)
 
-    def wait_for(self, task_id, callback, expires=None):
+    def wait_for(self, task_id, callback, expires=None, persistent=None):
         key = self.producer.app.backend.get_key_for_task(task_id)
         if expires:
             timeout = self.producer.conn_pool.io_loop.add_timeout(


### PR DESCRIPTION
Currently tornado-celery declares result queue with `durable=True` even if `CELERY_RESULT_PERSISTENT` is set to False and results in following error:

```
Received remote Channel.Close (406): PRECONDITION_FAILED - parameters for queue '8b2826c210924527a58f4c36a1467159' in vhost '/' not equivalent
```

This fix declare the queue durability using value of configured `CELERY_RESULT_PERSISTENT`.
