### PR TITLE
Cancel the consumer after callback executed

### DIFF
--- a/tcelery/producer.py
+++ b/tcelery/producer.py
@@ -12,6 +12,7 @@ from celery.utils import timeutils
 
 from .result import AsyncResult
 
+
 try:
     from .redis import RedisConsumer
 except ImportError:


### PR DESCRIPTION
Currently the consumer for result queue is not canceled after callback and keep lying around. This leads to result queue cannot be auto-deleted from RabbitMQ until the channel is closed and accumulated in RabbitMQ. This fix cancels / removes the consumer after received result and executed callback, thus allows result queues to be cleaned up.
