### PR TITLE
Auto create/bind exchange, queue as celery's behavior

### DIFF
--- a/tcelery/producer.py
+++ b/tcelery/producer.py
@@ -86,6 +86,11 @@ class NonBlockingTaskProducer(TaskProducer):
          self.encoder) = serialization.registry._encoders[self.serializer]
 
         conn = self.conn_pool.connection()
+
+        for entity in declare:
+            entity.maybe_bind(self.channel)
+            entity.declare()
+
         publish = conn.publish
         result = publish(body, priority=priority, content_type=content_type,
                          content_encoding=content_encoding, headers=headers,


### PR DESCRIPTION
Since celery itself auto create/bind exchange/queue for us, I thought tornado-celery should keep the same behavior? I bumped into the problem when setup a new MQ that has no existing exchange/queue or run unit test which auto point to randomly generated exchange/queue names. Not sure if there's some special considerations not to keep auto create behavior?

The patch I submitted just simply reuse kombu's(I've tested with 3.0.14) entity functionality, I know it's a blocking and non-tornado thing, however, the real I/O to MQ create/bind exchange/queue will only be called once when producer instance is created and publish task for the 1st time, for rest of 99.99% task-publishings it will just read from memory-cache, as for my best knowledge. I tested in my environment and turns out there's no impact on performance. FYR.
