### PR TITLE
make auto create/bind exchange/queue cache and retry

### DIFF
--- a/tcelery/producer.py
+++ b/tcelery/producer.py
@@ -5,6 +5,8 @@ from functools import partial
 from datetime import timedelta
 from kombu import serialization
 from kombu.utils import cached_property
+from kombu import common
+
 from celery.app.amqp import TaskProducer
 from celery.backends.amqp import AMQPBackend
 from celery.backends.redis import RedisBackend
@@ -87,9 +89,9 @@ class NonBlockingTaskProducer(TaskProducer):
 
         conn = self.conn_pool.connection()
 
+        # auto create/bind exchange/queue for the first call and caches
         for entity in declare:
-            entity.maybe_bind(self.channel)
-            entity.declare()
+            common.maybe_declare(entity, self.channel, retry=True)
 
         publish = conn.publish
         result = publish(body, priority=priority, content_type=content_type,


### PR DESCRIPTION
Refine auto create/bind exchange/queue to have cache, retry mechanism, which will increase performance and stability.
Otherwise in some network error scenarios (e.g. ELB auto close connection), the following error will occur and message cannot be sent to broker.
"
File "xxx/celery/app/task.py", line 555, in apply_async#012    *_dict(self._get_exec_options(), *_options)#012  File "xxx/celery/app/base.py", line 323, in send_task#012    reply_to=reply_to or self.oid, *_options#012  File "xxx/celery/app/amqp.py", line 302, in publish_task#012    *_kwargs#012  File "xxx/tcelery/producer.py", line 79, in publish#012    entity.declare()#012  File "xxx/kombu/entity.py", line 504, in declare#012    self.exchange.declare(nowait)#012  File "xxx/kombu/entity.py", line 166, in declare#012    nowait=nowait, passive=passive,#012  File "xxx/amqp/channel.py", line 620, in exchange_declare#012    (40, 11),  # Channel.exchange_declare_ok#012  File "xxx/amqp/abstract_channel.py", line 67, in wait#012    self.channel_id, allowed_methods)#012  File "xxx/amqp/connection.py", line 237, in _wait_method#012    self.method_reader.read_method()#012  File "xxx/amqp/method_framing.py", line 189, in read_method#012    raise m#012IOError: Socket closed
"
