### PR TITLE
Unknown package's dependencies in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if sys.version_info[0] >= 3:
     dependency_links.append(
         'https://github.com/renshawbay/pika-python3/archive/python3.zip#egg=pika-python3'
     )
-    install_requires.append('pika-python3')
+    install_requires.append('python3-pika')
 else:
     install_requires.append('pika')
 


### PR DESCRIPTION
Packages for Python 3 names python3-pika, not pika-python3
https://testpypi.python.org/pypi/python3-pika/0.9.14