### PR TITLE
nowait option to wait for async task result

### DIFF
--- a/tcelery/connection.py
+++ b/tcelery/connection.py
@@ -101,11 +101,11 @@ class Connection(object):
                                    body=body, properties=properties,
                                    mandatory=mandatory, immediate=immediate)
 
-    def consume(self, queue, callback, x_expires=None, persistent=True):
+    def consume(self, queue, callback, x_expires=None, persistent=True, nowait=True):
         assert self.channel
         self.channel.queue_declare(self.on_queue_declared, queue=queue,
                                    exclusive=False, auto_delete=True,
-                                   nowait=True, durable=persistent,
+                                   nowait=nowait, durable=persistent,
                                    arguments={'x-expires': x_expires})
         self.channel.basic_consume(callback, queue, no_ack=True)
 

--- a/tcelery/producer.py
+++ b/tcelery/producer.py
@@ -32,16 +32,18 @@ class AMQPConsumer(object):
             persistent = True
         conn = self.producer.conn_pool.connection()
 
+        nowait = self.producer.app.conf.get('TCELERY_RESULT_NOWAIT', True)
+
         def consume_callback(channel, deliver, properties, reply):
             callback(reply)
             try:
-                channel.basic_cancel(consumer_tag=deliver.consumer_tag, nowait=True)
+                channel.basic_cancel(consumer_tag=deliver.consumer_tag, nowait=nowait)
             except Exception:
                 pass
 
         conn.consume(task_id.replace('-', ''),
                      consume_callback,
-                     x_expires=expires, persistent=persistent)
+                     x_expires=expires, persistent=persistent, nowait=nowait)
 
 
 class NonBlockingTaskProducer(TaskProducer):


### PR DESCRIPTION
With 0.3.5, `yield gen.Task(taskxxx.apply_async)` is blocked forever without result. 
```
    @gen.coroutine
    def get(self):
        # this will be blocked forever
        yield gen.Task(hello.task_hello.apply_async, args=['world'])
        ...
        ...
```

It's because `nowait` flag is alway True for channel. So, I added option to it with 'TCELERY_RESULT_NOWAIT' as celery config.

Thanks,
Sangwon Lee